### PR TITLE
Fix dependency check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   prod-deploy:
-    needs: version
     uses: ./.github/workflows/prod-deploy.yml
     with:
       tag: ${{ inputs.tag }}


### PR DESCRIPTION
Remove the "needs: version" since we removed the version job