### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 # test-workflows
 
 [![CD](https://github.com/cmcculloh/test-workflows/actions/workflows/CD.yml/badge.svg?branch=master)](https://github.com/cmcculloh/test-workflows/actions/workflows/CD.yml)
-[![Release](https://github.com/cmcculloh/test-workflows/actions/workflows/release.yml/badge.svg)](https://github.com/cmcculloh/test-workflows/actions/workflows/release.yml)


### PR DESCRIPTION
Release tag is inaccurate. No idea why or how this actually works. Not only is it a false positive sometimes, but it is redundant since you can see release environment statuses over on the right hand side of the page anyways.
